### PR TITLE
ホールドエリア追加によるレイアウト見直し

### DIFF
--- a/src/components/holdArea.ts
+++ b/src/components/holdArea.ts
@@ -1,6 +1,6 @@
 /**
- * スコア表示エリアのdiv要素を作成する関数
- * @return {HTMLDivElement} スコア表示エリアのdiv要素
+ * ホールドしたテトリミノ表示エリアのdiv要素を作成する関数
+ * @return {HTMLDivElement} ホールドしたテトリミノ表示エリアのdiv要素
  */
 export const createHoldArea = (): HTMLDivElement => {
   let container = document.createElement('div');

--- a/src/components/holdArea.ts
+++ b/src/components/holdArea.ts
@@ -4,7 +4,7 @@
  */
 export const createHoldArea = (): HTMLDivElement => {
   let container = document.createElement('div');
-  // レスポンシブのグリッド幅(スマホ：100%, タブレット:50%、　PC：1/3)
+  // レスポンシブのグリッド幅(スマホ：表示なし, タブレット:50%、PC：1/3)
   container.classList.add(
     'd-none',
     'd-sm-block',

--- a/src/components/holdArea.ts
+++ b/src/components/holdArea.ts
@@ -1,0 +1,27 @@
+/**
+ * スコア表示エリアのdiv要素を作成する関数
+ * @return {HTMLDivElement} スコア表示エリアのdiv要素
+ */
+export const createHoldArea = (): HTMLDivElement => {
+  let container = document.createElement('div');
+  // レスポンシブのグリッド幅(スマホ：100%, タブレット:50%、　PC：1/3)
+  container.classList.add(
+    'd-none',
+    'd-sm-block',
+    'd-md-block',
+    'col-12',
+    'col-sm-6',
+    'col-lg',
+    'order-lg-1'
+  );
+
+  container.innerHTML = `
+    <div class="d-flex justify-content-sm-end">
+      <div class="hold-area bg-dark p-2">
+        <p class="h5 text-center text-white">HOLD</p>
+      </div>
+    </div>  
+  `;
+
+  return container;
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,7 @@
+export * from "./gameArea"
+export * from "./holdArea"
+export * from "./nextArea"
+export * from "./pausedModal"
+export * from "./scoreArea"
+export * from "./titleArea"
+

--- a/src/components/nextArea.ts
+++ b/src/components/nextArea.ts
@@ -4,7 +4,7 @@
  */
 export const createNextArea = (): HTMLDivElement => {
   let container = document.createElement('div');
-  // レスポンシブのグリッド幅(スマホ：表示なし, タブレット:50%、　PC：1/3)
+  // レスポンシブのグリッド幅(スマホ：表示なし, タブレット:50%、 PC：1/3)
   container.classList.add('d-none', 'd-sm-block', 'd-md-block');
 
   container.innerHTML = `

--- a/src/components/nextArea.ts
+++ b/src/components/nextArea.ts
@@ -5,14 +5,11 @@
 export const createNextArea = (): HTMLDivElement => {
   let container = document.createElement('div');
   // レスポンシブのグリッド幅(スマホ：表示なし, タブレット:50%、　PC：1/3)
-  container.classList.add('d-none', 'd-sm-block', 'd-md-block', 'col-sm-6', 'col-lg', 'order-lg-3');
+  container.classList.add('d-none', 'd-sm-block', 'd-md-block');
 
   container.innerHTML = `
     <div class="next-area bg-dark p-2">
       <p class="h5 text-center text-white">NEXT</p>
-    </div>
-    <div class="hold-area bg-dark p-2">
-      <p class="h5 text-center text-white">HOLD</p>
     </div>
   `;
 

--- a/src/components/scoreArea.ts
+++ b/src/components/scoreArea.ts
@@ -4,16 +4,13 @@
  */
 export const createScoreArea = (): HTMLDivElement => {
   let container = document.createElement('div');
-  // レスポンシブのグリッド幅(スマホ：100%, タブレット:50%、　PC：1/3)
-  container.classList.add('col-12', 'col-sm-6', 'col-lg', 'order-lg-1');
+  container.classList.add('mt-4');
 
   container.innerHTML = `
-    <div class="d-flex justify-content-center justify-content-sm-end">
-      <div class="score-area bg-dark text-white p-2">
-        <p class="h5">SCORE</p>
-        <p class="h2 text-right" id="score">0</p>
-      </div>
-    </div>  
+    <div class="score-area bg-dark text-white mx-auto mx-sm-0 p-2">
+      <p class="h5">SCORE</p>
+      <p class="h2 text-right" id="score">0</p>
+    </div>
   `;
 
   return container;

--- a/src/components/scoreArea.ts
+++ b/src/components/scoreArea.ts
@@ -4,14 +4,14 @@
  */
 export const createScoreArea = (): HTMLDivElement => {
   let container = document.createElement('div');
-  container.classList.add('mt-4');
+  container.classList.add('d-flex', "flex-sm-column", 'mt-4');
 
   container.innerHTML = `
-    <div class="score-area bg-dark text-white mx-auto mx-sm-0 p-2">
+    <div class="score-area bg-dark text-white mx-auto mx-sm-0 mb-2 p-2">
       <p class="h5">SCORE</p>
       <p class="h2 text-right" id="score">0</p>
     </div>
-    <div class="score-area bg-dark text-white mx-auto mx-sm-0 mt-2 p-2">
+    <div class="score-area bg-dark text-white mx-auto mx-sm-0 p-2">
       <p class="h5">MAX SCORE</p>
       <p class="h2 text-right" id="max-score">0</p>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,7 +12,7 @@ p {
 }
 
 .score-area {
-  width: 200px;
+  width: 150px;
   height: 90px;
 }
 
@@ -24,7 +24,6 @@ p {
 .hold-area {
   width: 150px;
   height: 200px;
-  margin-top: 78px;
 }
 
 .pause-button {

--- a/src/views/gamePlayPage.ts
+++ b/src/views/gamePlayPage.ts
@@ -13,7 +13,7 @@ import {
  */
 export const createGamePlayPage = (): HTMLDivElement => {
   let container = document.createElement('div');
-  container.classList.add('bg-lightblue', 'vh-100');
+  container.classList.add('bg-lightblue', 'min-vh-100');
 
   let grid = document.createElement('div');
   grid.classList.add('container');

--- a/src/views/gamePlayPage.ts
+++ b/src/views/gamePlayPage.ts
@@ -3,6 +3,7 @@ import { createNextArea } from '../components/nextArea';
 import { createScoreArea } from '../components/scoreArea';
 import { createPausedModal } from '../components/pausedModal';
 import { createTitleArea } from '../components/titleArea';
+import { createHoldArea } from '../components/holdArea';
 
 /**
  * ゲーム画面ページを作成する関数
@@ -19,12 +20,19 @@ export const createGamePlayPage = (): HTMLDivElement => {
   row.classList.add('row');
 
   const titleArea = createTitleArea();
-  const scoreArea = createScoreArea();
+  const holdArea = createHoldArea();
   const gameArea = createGameArea();
   const nextArea = createNextArea();
+  const scoreArea = createScoreArea();
   const pausedModal = createPausedModal();
 
-  row.append(gameArea, scoreArea, nextArea);
+  // PCサイズの右側エリア（NEXTとSCORE）
+  let rightArea = document.createElement('div');
+  // レスポンシブのグリッド幅(スマホ：100%, タブレット:50%、　PC：1/3)
+  rightArea.classList.add('col-12', 'col-sm-6', 'col-lg', 'order-lg-3');
+  rightArea.append(nextArea, scoreArea);
+
+  row.append(gameArea, holdArea, rightArea);
   grid.append(titleArea, row);
   container.append(grid, pausedModal);
 

--- a/src/views/gamePlayPage.ts
+++ b/src/views/gamePlayPage.ts
@@ -1,9 +1,11 @@
-import { createGameArea } from '../components/gameArea';
-import { createNextArea } from '../components/nextArea';
-import { createScoreArea } from '../components/scoreArea';
-import { createPausedModal } from '../components/pausedModal';
-import { createTitleArea } from '../components/titleArea';
-import { createHoldArea } from '../components/holdArea';
+import {
+  createGameArea,
+  createHoldArea,
+  createNextArea,
+  createPausedModal,
+  createScoreArea,
+  createTitleArea,
+} from '../components';
 
 /**
  * ゲーム画面ページを作成する関数


### PR DESCRIPTION
PCサイズも含めてレイアウトを修正しました。

PC
<img width="1434" alt="スクリーンショット 2022-12-17 17 15 47" src="https://user-images.githubusercontent.com/83049578/208232808-6f0f4d9b-d131-422e-8d5d-ca34a76327f8.png">

タブレット
<img width="445" alt="スクリーンショット 2022-12-17 17 16 12" src="https://user-images.githubusercontent.com/83049578/208232816-548efdf5-1622-41af-bda6-b0802a940b9b.png">

スマホ
<img width="309" alt="スクリーンショット 2022-12-17 17 16 27" src="https://user-images.githubusercontent.com/83049578/208232823-87436e46-3320-4d6b-99df-aaf78c40147c.png">